### PR TITLE
Implement Discord bot commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# Synthara Discord Bot
+
+This repository contains a simple Discord bot using `discord.py`.
+
+## Configuration
+
+The bot looks for two environment variables when running:
+
+- `DISCORD_TOKEN` – the Discord bot token.
+- `OWNER_ID` – the numeric Discord ID of the bot owner.
+
+User information is stored in `user_stats.json`. This file is created
+automatically when the bot runs for the first time.
+
+## Slash Commands
+
+* `/ping` – return the current gateway latency.
+* `/uptime` – show how long the bot has been running.
+* `/remove_user <ID>` – delete a user from the whitelist. Only the owner
+  can run this command.
+* `/config-user <set-pro|view-stats> <ID>` – mark a user as pro or view
+  their usage statistics.
+* `/model <model>` – request a model. If the model is considered
+  pro‑only (for example `gpt-4`), non‑pro users will receive the message
+  "Sorry, you're not authenticated to use this model".
+
+## User Statistics
+
+Each user entry in `user_stats.json` stores:
+
+- `is_pro` – whether the user has access to pro-only models.
+- `command_count` – how many commands the user has issued.
+- `token_usage` – cumulative token usage (placeholder value).
+- `last_use` – ISO timestamp of the last command used.
+
+Statistics are updated whenever a slash command is executed.

--- a/bot.py
+++ b/bot.py
@@ -1,0 +1,137 @@
+import json
+import os
+from datetime import datetime
+
+import discord
+from discord.ext import commands
+from discord import app_commands
+
+DATA_FILE = 'user_stats.json'
+OWNER_ID = int(os.environ.get('OWNER_ID', '0'))
+PRO_MODELS = {'gpt-4', 'gpt-4-32k'}
+
+start_time = datetime.utcnow()
+
+
+def load_data():
+    if os.path.isfile(DATA_FILE):
+        with open(DATA_FILE, 'r') as f:
+            return json.load(f)
+    return {}
+
+
+def save_data(data):
+    with open(DATA_FILE, 'w') as f:
+        json.dump(data, f, indent=2)
+
+
+def get_user(data, uid):
+    uid = str(uid)
+    if uid not in data:
+        data[uid] = {
+            'is_pro': False,
+            'command_count': 0,
+            'token_usage': 0,
+            'last_use': None,
+        }
+    return data[uid]
+
+
+def update_usage(uid, tokens=0):
+    data = load_data()
+    user = get_user(data, uid)
+    user['command_count'] += 1
+    user['token_usage'] += tokens
+    user['last_use'] = datetime.utcnow().isoformat()
+    save_data(data)
+
+
+def is_pro(uid):
+    data = load_data()
+    return get_user(data, uid).get('is_pro', False)
+
+
+def check_pro_model(uid, model):
+    if model in PRO_MODELS and not is_pro(uid):
+        return False
+    return True
+
+
+intents = discord.Intents.default()
+bot = commands.Bot(command_prefix='!', intents=intents)
+
+
+@bot.event
+async def on_ready():
+    await bot.tree.sync()
+    print(f'Logged in as {bot.user}')
+
+
+@bot.tree.command(name='ping', description='Return the gateway ping')
+async def ping(interaction: discord.Interaction):
+    update_usage(interaction.user.id)
+    latency_ms = round(bot.latency * 1000)
+    await interaction.response.send_message(f'Pong! {latency_ms} ms')
+
+
+@bot.tree.command(name='uptime', description='Show how long the bot has been running')
+async def uptime(interaction: discord.Interaction):
+    update_usage(interaction.user.id)
+    delta = datetime.utcnow() - start_time
+    hours, remainder = divmod(int(delta.total_seconds()), 3600)
+    minutes, seconds = divmod(remainder, 60)
+    await interaction.response.send_message(f'Uptime: {hours}h {minutes}m {seconds}s')
+
+
+@bot.tree.command(name='remove_user', description='Delete a user from the whitelist')
+async def remove_user(interaction: discord.Interaction, user_id: str):
+    if interaction.user.id != OWNER_ID:
+        await interaction.response.send_message('You do not have permission to use this command.', ephemeral=True)
+        return
+    data = load_data()
+    if user_id in data:
+        del data[user_id]
+        save_data(data)
+        await interaction.response.send_message(f'Removed user {user_id}', ephemeral=True)
+    else:
+        await interaction.response.send_message('User not found.', ephemeral=True)
+
+
+@bot.tree.command(name='config-user', description='Set pro status or view user stats')
+@app_commands.describe(action='"set-pro" to grant pro access, "view-stats" to show usage stats', user_id='Target user ID')
+async def config_user(interaction: discord.Interaction, action: str, user_id: str):
+    if interaction.user.id != OWNER_ID:
+        await interaction.response.send_message('You do not have permission to use this command.', ephemeral=True)
+        return
+    data = load_data()
+    user = get_user(data, user_id)
+    if action == 'set-pro':
+        user['is_pro'] = True
+        save_data(data)
+        await interaction.response.send_message(f'User {user_id} marked as pro.', ephemeral=True)
+    elif action == 'view-stats':
+        msg = (f"Pro: {user['is_pro']}, Commands: {user['command_count']}, "
+               f"Tokens: {user['token_usage']}, Last use: {user['last_use']}")
+        await interaction.response.send_message(msg, ephemeral=True)
+    else:
+        await interaction.response.send_message('Invalid action.', ephemeral=True)
+
+
+@bot.tree.command(name='model', description='Request a model (demo)')
+async def model_cmd(interaction: discord.Interaction, model: str):
+    update_usage(interaction.user.id)
+    if not check_pro_model(interaction.user.id, model):
+        await interaction.response.send_message("Sorry, you're not authenticated to use this model", ephemeral=True)
+        return
+    await interaction.response.send_message(f'Model {model} accepted (dummy response)')
+
+
+def run():
+    token = os.environ.get('DISCORD_TOKEN')
+    if not token:
+        raise RuntimeError('DISCORD_TOKEN environment variable not set')
+    bot.run(token)
+
+
+if __name__ == '__main__':
+    run()


### PR DESCRIPTION
## Summary
- add a basic Discord bot in `bot.py`
- track user statistics and pro access in `user_stats.json`
- implement `/ping`, `/uptime`, `/remove_user`, `/config-user` and `/model`
- document commands and configuration in `README.md`

## Testing
- `python3 -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_6862b92d9ddc8320894c61c39afd12c6